### PR TITLE
Reload the page if a script error occurs.

### DIFF
--- a/launcher.user.js
+++ b/launcher.user.js
@@ -1824,3 +1824,8 @@ m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
 })(window,document,'script','//www.google-analytics.com/analytics.js','apos');
 
 apos('create', 'UA-64394184-1', 'auto');
+
+//Reload the page on script errors.
+window.onerror = function() {
+    location.reload();
+};


### PR DESCRIPTION
Sometimes the bot or the game crashes. If you just want to have it running in the background, an automatic-reload function is very useful.
This uses window.onerror to monitor script errors.