### PR TITLE
Avoid cells larger than twice the size + 30%

### DIFF
--- a/bot.user.js
+++ b/bot.user.js
@@ -138,7 +138,7 @@ console.log("Running Apos Bot!");
     }
 
     function canSplit(player1, player2) {
-        return compareSize(player1, player2, 2.30) && !compareSize(player1, player2, 7);
+        return compareSize(player1, player2, 2.30);// && !compareSize(player1, player2, 7);
     }
 
     function isItMe(player, cell2) {
@@ -185,14 +185,14 @@ console.log("Running Apos Bot!");
     }
 
     function isFood(blob, cell) {
-        if (!cell.isVirus() && compareSize(cell, blob, 1.30) || (cell.size <= 11)) {
+        if (/*!cell.isVirus() && compareSize(cell, blob, 1.30) ||*/ (cell.size <= 15)) {
             return true;
         }
         return false;
     }
 
     function isThreat(blob, cell) {
-        if (!cell.isVirus() && compareSize(blob, cell, 1.30)) {
+        if (!cell.isVirus() && compareSize(blob, cell, 1.10)) {
             return true;
         }
         return false;


### PR DESCRIPTION
Removed the !compareSize(player1, player2, 7); which purposely ignores cells 7x larger than blob; This allows for avoidance of unnecessary dangers.

Increased cell size to 15 or less for food, since some foods are larger than 11. 
Removed the requirement /*!cell.isVirus() && compareSize(cell, blob, 1.30) ||*/ because chasing smaller cells doesn't normally succeed. Usually, only cornering cells succeeds, but I haven't implemented that here.

Made cells larger than 10% of blob threats, a more accurate number.

Issues remaining: since in the presence of many larger cells, the angles to run out of the situation are zero. This needs to be fixed. Also, in the case of a 4/8-split from another cell, should that cell be re-joined, my blob will be eaten. 

I gain a larger average using this version than the current one, reaching scores of 100+ on average instead of what is currently, 50. My best score is a 364 in 349 seconds.
![screen__](https://cloud.githubusercontent.com/assets/5194299/9097951/e4be488a-3b94-11e5-85b2-12e5bfa84998.png)
