### PR TITLE
Remove food in shift distance of danger zones

### DIFF
--- a/bot.user.js
+++ b/bot.user.js
@@ -857,10 +857,10 @@ function AposBot() {
                         //console.log("Found distance.");
 
                         var enemyCanSplit = this.canSplit(player[k], allPossibleThreats[i]);
+                        var secureDistance = (enemyCanSplit ? splitDangerDistance : normalDangerDistance);
                         
                         for (var j = clusterAllFood.length - 1; j >= 0 ; j--) {
-                            var secureDistance = (enemyCanSplit ? splitDangerDistance : normalDangerDistance);
-                            if (this.computeDistance(allPossibleThreats[i].x, allPossibleThreats[i].y, clusterAllFood[j][0], clusterAllFood[j][1]) < secureDistance)
+                            if (this.computeDistance(allPossibleThreats[i].x, allPossibleThreats[i].y, clusterAllFood[j][0], clusterAllFood[j][1]) < secureDistance + shiftDistance)
                                 clusterAllFood.splice(j, 1);
                         }
 


### PR DESCRIPTION
When searching for threats, I suggest removing food from the food list within the shift distance of the danger zone.

![untitled](https://cloud.githubusercontent.com/assets/4460538/9865485/81da11e6-5b2d-11e5-9f30-de032c34bc5f.png)

This makes the bot smoother when chased by enemies.

Quite often I saw the bot going after a food close to the danger zone and immediately giving up when the enemy moves closer.