### PR TITLE
Fixed a connection issue

### DIFF
--- a/launcher.user.js
+++ b/launcher.user.js
@@ -391,7 +391,7 @@ console.log("Running Bot Launcher!");
             O(a);
             a = N(5);
             a.setUint8(0, 255);
-            a.setUint32(1, 2200049715, !0);
+            a.setUint32(1, 154669603, !0);
             O(a);
             a = N(1 + b.length);
             a.setUint8(0, 80);


### PR DESCRIPTION
This issue is due to the Client -> Server Protocol. The client sends three messages with the opcodes 254, 255 and 80 when it connects. Opcode 255 sends an unsigned integer "initialise key" to the server which is like a handshake, to verify you are a valid user.
The "initialise key" used now is "2200049715" but due to some unknown reason, it doesn't let you connect to the server. I have replaced this with "154669603" which fixes this and lets you to connect to the server **but there are still bugs which need to be addressed to make this work.**