### PR TITLE
Virus detection code changed

### DIFF
--- a/bot.user.js
+++ b/bot.user.js
@@ -284,20 +284,15 @@ function AposBot() {
         }
         return false;
     };
-
+    
     this.isVirus = function(blob, cell) {
-        if (blob == null) {
-            if (cell.isVirus()){return true;}
-            else {return false;}
-        }
-
-        if (cell.isVirus() && this.compareSize(cell, blob, 1.2)) {
-            return true;
-        } else if (cell.isVirus() && cell.color.substring(3,5).toLowerCase() != "ff") {
-            return true;
-        }
-        return false;
-    };
+    if (cell.isVirus() && this.compareSize(cell, blob, 1.1)) {
+        return true;
+    } else if (cell.isVirus() && cell.color.substring(3, 5).toLowerCase() != "ff") {
+        return true;
+    }
+    return false;
+};
 
     this.isSplitTarget = function(that, blob, cell) {
         if (that.canSplit(cell, blob)) {


### PR DESCRIPTION
The number has been brought down to 1.1 for several reasons. If the value is mathematically perfect then the bot can hover above a virus (as it can't eat it, it won't think it's a threat) but often there are people under the virus and it will go for them (remember for the bot the virus doesn't exist). Also even if there is no player hiding under the virus, if it hovers over a virus, people tend to try and feed you just to make you pop.