### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ https://www.youtube.com/watch?v=Zvq38nmCm1s - Install Tutorial.
 
 https://www.youtube.com/watch?v=x2-DFRnEFBU - Android Tutorial.
 
-#Hotkeys
+# Hotkeys
 
 * Press 'R' if you want to toggle the line and dot drawing.
 * Press 'T' if you want to use the manual controls.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
